### PR TITLE
feat: shows logs from pods labelled with cicd-pod-logging=enabled

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -119,3 +119,14 @@ jobs:
       - name: Deploy microservice
         run: |
           make pgsql start
+
+      - name: Failure Pod Logging
+        if: ${{ failure() }}
+        run: |
+          for namespace in $(kubectl get namespaces --no-headers -o custom-columns=":metadata.name")
+          do
+            echo "Namespace: ${namespace} Logs:"
+            kubectl logs -l cicd-pod-logging=enabled -n "${namespace}" --tail=1000
+            echo "------------------------------------------------------------------------------------------------------------------"
+            echo ""
+          done


### PR DESCRIPTION
This is particularly useful when running the deployment tests. I came across a situation where locally the pr check was working, and not on github actions. 

This github action is an example of how this utility can help debug what's wrong. All I had to do is to add a label to the running pod, and I got the logs when it failed. https://github.com/GiGInnovationLabs/endeavour-dwh/runs/5689966523?check_suite_focus=true